### PR TITLE
Old style one line gnuplot if statement

### DIFF
--- a/scripts/mummerplot.pl
+++ b/scripts/mummerplot.pl
@@ -1152,7 +1152,7 @@ sub WriteGP ($$)
         $P_KEY = "unset key";
         $P_FORMAT .= "\nset mouse format \"$TFORMAT\"";
         $P_FORMAT .= "\nset mouse mouseformat \"$MFORMAT\"";
-        $P_FORMAT .= "\nif(GPVAL_VERSION < 5) { set mouse clipboardformat \"$MFORMAT\" }";
+        $P_FORMAT .= "\nif(GPVAL_VERSION < 5) set mouse clipboardformat \"$MFORMAT\"";
     }
     else {
         $P_LS = "set linestyle";


### PR DESCRIPTION
Fix proposed in #41 by @bredeson

Support for curly braces (mainly for multiple line if-statements) will not work on older versions of gnuplot.