### PR TITLE
Use single quotes to support '@' in libpaths.

### DIFF
--- a/scripts/dnadiff.pl
+++ b/scripts/dnadiff.pl
@@ -9,14 +9,14 @@
 #
 #-------------------------------------------------------------------------------
 
-use lib "@LIB_DIR@";
+use lib '@LIB_DIR@';
 use Foundation;
 use File::Spec::Functions;
 use warnings;
 use strict;
 
-my $BIN_DIR = "@BIN_DIR@";
-my $SCRIPT_DIR = "@LIB_DIR@";
+my $BIN_DIR = '@BIN_DIR@';
+my $SCRIPT_DIR = '@LIB_DIR@';
 
 my $VERSION_INFO = q~
 DNAdiff version 1.3

--- a/scripts/mapview.pl
+++ b/scripts/mapview.pl
@@ -1,9 +1,9 @@
 #!@PERL@
 
-use lib "@LIB_DIR@";
+use lib '@LIB_DIR@';
 use Foundation;
 
-my $SCRIPT_DIR = "@LIB_DIR@";
+my $SCRIPT_DIR = '@LIB_DIR@';
 
 
 my $VERSION_INFO = q~

--- a/scripts/mummerplot.pl
+++ b/scripts/mummerplot.pl
@@ -16,14 +16,14 @@
 # 
 ################################################################################
 
-use lib "@LIB_DIR@";
+use lib '@LIB_DIR@';
 use Foundation;
 use strict;
 use IO::Socket;
 
-my $BIN_DIR     = "@BIN_DIR@";
-my $LIB_DIR     = "@LIB_DIR@";
-my $GNUPLOT_EXE = "@GNUPLOT_EXE@";
+my $BIN_DIR     = '@BIN_DIR@';
+my $LIB_DIR     = '@LIB_DIR@';
+my $GNUPLOT_EXE = '@GNUPLOT_EXE@';
 
 
 #================================================================= Globals ====#

--- a/scripts/nucmer.pl.~1.5.~
+++ b/scripts/nucmer.pl.~1.5.~
@@ -15,14 +15,14 @@
 #
 #-------------------------------------------------------------------------------
 
-use lib "__SCRIPT_DIR";
+use lib '__SCRIPT_DIR';
 use Foundation;
 use File::Spec::Functions;
 use strict;
 
-my $AUX_BIN_DIR = "__AUX_BIN_DIR";
-my $BIN_DIR = "__BIN_DIR";
-my $SCRIPT_DIR = "__SCRIPT_DIR";
+my $AUX_BIN_DIR = '__AUX_BIN_DIR';
+my $BIN_DIR = '__BIN_DIR';
+my $SCRIPT_DIR = '__SCRIPT_DIR';
 
 
 my $VERSION_INFO = q~

--- a/scripts/nucmer_ori.pl
+++ b/scripts/nucmer_ori.pl
@@ -15,14 +15,14 @@
 #
 #-------------------------------------------------------------------------------
 
-use lib "__SCRIPT_DIR";
+use lib '__SCRIPT_DIR';
 use Foundation;
 use File::Spec::Functions;
 use strict;
 
-my $AUX_BIN_DIR = "__AUX_BIN_DIR";
-my $BIN_DIR = "__BIN_DIR";
-my $SCRIPT_DIR = "__SCRIPT_DIR";
+my $AUX_BIN_DIR = '__AUX_BIN_DIR';
+my $BIN_DIR = '__BIN_DIR';
+my $SCRIPT_DIR = '__SCRIPT_DIR';
 
 
 my $VERSION_INFO = q~

--- a/scripts/promer.pl
+++ b/scripts/promer.pl
@@ -15,14 +15,14 @@
 #
 #-------------------------------------------------------------------------------
 
-use lib "@LIB_DIR@";
+use lib '@LIB_DIR@';
 use Foundation;
 use File::Spec::Functions;
 use strict;
 
-my $BIN_DIR = "@BIN_DIR@";
-my $AUX_BIN_DIR = "@LIBEXEC_DIR@";
-my $LIB_DIR = "@LIB_DIR@";
+my $BIN_DIR = '@BIN_DIR@';
+my $AUX_BIN_DIR = '@LIBEXEC_DIR@';
+my $LIB_DIR = '@LIB_DIR@';
 
 
 


### PR DESCRIPTION
Conda mulled environments for Galaxy will frequently create paths like

`/path/to/conda/envs/__mummer4@4.0.0beta2`

With double quotes, the `use lib` directive attempts to interpolate `@4` in that path, and thus cannot find `Foundation.pm`

This pull request works around perl being silly like that. I've tested `dnadiff` and `mummerplot`, the other scripts should function the same way.