### PR TITLE
Fix incorrect crash with "ERROR: sequence <name> was not found in the query file."

### DIFF
--- a/src/tigr/show-tiling.cc
+++ b/src/tigr/show-tiling.cc
@@ -829,24 +829,22 @@ void outputPseudoMolecule
   long int InitSize = INIT_SIZE;
   char Line [MAX_LINE];
 
-
   //-- Read in the needed query contig sequences
   A = new char[InitSize];
   while ( Read_String (QryFile, A, InitSize, Line, false) )
     {
+      // NOTE: if a chromosome occurs multiple times in a tiling, we need to
+      //       store the query sequence each time.
       for ( Cp = Contigs.begin( ); Cp < Contigs.end( ); Cp ++ )
 	if ( Cp->TileLevel == USED_TILE_LEVEL )
           if ( string(Line) == Cp->IdQ )
-	    break;
-      
-      if ( Cp < Contigs.end( ) )
-	{
-	  assert ( (long int)strlen(A+1) == Cp->SeqLenQ );
-	  Cp->SeqQ = new char [Cp->SeqLenQ + 2];
-	  Cp->SeqQ[0] = '\0';
-	  strcpy ( Cp->SeqQ + 1, A + 1 );
-	  if ( Cp->DirQ == REVERSE_CHAR )
-	    Reverse_Complement (Cp->SeqQ, 1, Cp->SeqLenQ);
+          {
+            assert ( (long int)strlen(A+1) == Cp->SeqLenQ );
+            Cp->SeqQ = new char [Cp->SeqLenQ + 2];
+            Cp->SeqQ[0] = '\0';
+            strcpy ( Cp->SeqQ + 1, A + 1 );
+            if ( Cp->DirQ == REVERSE_CHAR )
+              Reverse_Complement (Cp->SeqQ, 1, Cp->SeqLenQ);
 	}
     }
   delete[] A;

--- a/src/tigr/show-tiling.cc
+++ b/src/tigr/show-tiling.cc
@@ -75,7 +75,7 @@ struct AlignStats
 struct QueryContig
      //-- Query sequence tiling contig data structure
 {
-  char * IdQ;                              // FASTA Id of the query
+  string IdQ;                              // FASTA Id of the query
   long int SeqLenQ;                        // length of the query
   char * SeqQ;                             // query sequence
 
@@ -151,7 +151,7 @@ struct IdQ_Sort
   bool operator( ) (const QueryContig & pA, const QueryContig & pB)
   {
     //-- sort IdQ
-    if ( strcmp (pA.IdQ, pB.IdQ) < 0 )
+    if ( pA.IdQ < pB.IdQ )
       return true;
     else
       return false;
@@ -795,13 +795,13 @@ void outputContigs
 	  if ( Cp->DirQ == FORWARD_CHAR )
 	    fprintf(Output,
             "#%s(%ld) [%s] %ld bases, 00000000 checksum. {%ld %ld} <%ld %ld>\n",
-		    Cp->IdQ, Cp->StartR + Cp->LoTrim - 1, "", Cp->SeqLenQ,
+		    Cp->IdQ.c_str(), Cp->StartR + Cp->LoTrim - 1, "", Cp->SeqLenQ,
 		    Cp->LoTrim + 1, Cp->SeqLenQ - Cp->HiTrim,
 		    Cp->StartR + Cp->LoTrim, Cp->EndR - Cp->HiTrim);
 	  else
 	    fprintf(Output,
             "#%s(%ld) [%s] %ld bases, 00000000 checksum. {%ld %ld} <%ld %ld>\n",
-		    Cp->IdQ, Cp->StartR + Cp->LoTrim - 1, "RC", Cp->SeqLenQ,
+		    Cp->IdQ.c_str(), Cp->StartR + Cp->LoTrim - 1, "RC", Cp->SeqLenQ,
 		    Cp->SeqLenQ - Cp->LoTrim, Cp->HiTrim + 1,
 		    Cp->StartR + Cp->LoTrim, Cp->EndR - Cp->HiTrim);
 	}
@@ -836,7 +836,7 @@ void outputPseudoMolecule
     {
       for ( Cp = Contigs.begin( ); Cp < Contigs.end( ); Cp ++ )
 	if ( Cp->TileLevel == USED_TILE_LEVEL )
-	  if ( strcmp ( Line, Cp->IdQ ) == 0 )
+          if ( string(Line) == Cp->IdQ )
 	    break;
       
       if ( Cp < Contigs.end( ) )
@@ -908,7 +908,7 @@ void outputPseudoMolecule
 		 "\nERROR: Sequence \"%s\" was not found in the query file.\n"
 		 "       Please check the validity of the query file listed\n"
 		 "       at the top of the .delta input file and rerun.\n",
-		       Cp->IdQ);
+		       Cp->IdQ.c_str());
 	      exit (EXIT_FAILURE);
 	    }
 
@@ -989,7 +989,7 @@ void parseDelta
 {
   vector<QueryContig>::iterator Cp;
 
-  char * CurrIdQ;                        // the current contig Id
+  string CurrIdQ;                        // the current contig Id
   long int temp;
 
   QueryContig aContig;                   //  single query contig
@@ -1004,7 +1004,7 @@ void parseDelta
 
 
   Contigs.clear( );
-  CurrIdQ = NULL_STRING;
+
   aContig.SeqQ = NULL;
   aContig.DirQ = '*';
   aContig.IdR = NULL_STRING;
@@ -1046,10 +1046,9 @@ void parseDelta
       aContig.SeqLenQ = dr.getRecord( ).lenQ;
       
       aStats.IdR = dr.getRecord( ).idR;
-      aContig.IdQ = new char[dr.getRecord( ).idQ.length( ) + 1];
-      strcpy (aContig.IdQ, dr.getRecord( ).idQ.c_str( ));
+      aContig.IdQ = dr.getRecord( ).idQ;
 
-      if ( strcmp (CurrIdQ, aContig.IdQ) )
+      if ( CurrIdQ != aContig.IdQ )
 	{
 	  CurrIdQ = aContig.IdQ;
 	  aContig.TileLevel = aContig.SeqLenQ < MIN_CONTIG_LENGTH ?
@@ -1191,7 +1190,7 @@ void printAlignment
   fprintf(Output,"%.2f\t", Ap->Idy);
   fprintf(Output,"%ld\t%ld\t", Ap->SeqLenR, Cp->SeqLenQ);
   fprintf(Output,"%.2f\t%.2f\t", covA, covB);
-  fprintf(Output,"%s\t%s", Ap->IdR.c_str(), Cp->IdQ);
+  fprintf(Output,"%s\t%s", Ap->IdR.c_str(), Cp->IdQ.c_str());
   fprintf(Output,"\n"); 
 
   return;
@@ -1280,7 +1279,7 @@ void printTilingPath
 	  //-- Print the data
 	  printf ("%ld\t%ld\t%ld\t%ld\t%.2f\t%.2f\t%c\t%s\n",
 		  Cp->StartR, Cp->EndR, gap, len, pcov,
-		  pidy, Cp->DirQ, Cp->IdQ);
+		  pidy, Cp->DirQ, Cp->IdQ.c_str());
 
 	  //-- Walk the pointer down the list of contigs
 	  if ( Cp->linksTo == Contigs.end( )  ||  Cp->linksTo->isLinkHead )
@@ -1335,7 +1334,7 @@ void printTilingXML
 	{
 	  printf
 	    ("\t<CONTIG ID = \"contig_%s\" NAME = \"%s\" LEN = \"%ld\"/>\n",
-	     Cp->IdQ, Cp->IdQ, Cp->SeqLenQ);
+	     Cp->IdQ.c_str(), Cp->IdQ.c_str(), Cp->SeqLenQ);
 
 	  //-- Walk the pointer down the list of contigs
 	  if ( Cp->linksTo == Contigs.end( )  ||  Cp->linksTo->isLinkHead )
@@ -1372,7 +1371,7 @@ void printTilingXML
 	    ("\t<LINK ID = \"link_%ld\" SIZE = \"%ld\" TYPE = \"MUMmer\">\n",
 	     ++ ct, gap);
 	  printf("\t\t<CONTIG ID = \"contig_%s\" ORI = \"%s\">\n",
-		 Cp->IdQ, Cp->DirQ == FORWARD_CHAR ? "BE" : "EB");
+		 Cp->IdQ.c_str(), Cp->DirQ == FORWARD_CHAR ? "BE" : "EB");
 
 	  for ( Ap = Cp->Aligns.begin( );
 		Ap < Cp->Aligns.end( ); Ap ++ )
@@ -1386,7 +1385,7 @@ void printTilingXML
 
 	  printf("\t\t</CONTIG>\n");
 	  printf("\t\t<CONTIG ID = \"contig_%s\" ORI = \"%s\">\n",
-		 Cp->linksTo->IdQ,
+		 Cp->linksTo->IdQ.c_str(),
 		 Cp->linksTo->DirQ == FORWARD_CHAR ? "BE" : "EB");
 
 	  for ( Ap = Cp->linksTo->Aligns.begin( );

--- a/src/tigr/show-tiling.cc
+++ b/src/tigr/show-tiling.cc
@@ -683,7 +683,7 @@ long int longestConsistentSubset
 
   //-- Build the data array
   N = 0;
-  A = (node *) Safe_malloc (sizeof(node) * (end - begin));
+  A = new node [end - begin];
   for ( Ap = begin; Ap < end; Ap ++ )
     {
       assert ( Ap->isTiled == false );
@@ -750,7 +750,7 @@ long int longestConsistentSubset
 
   Best = A[Best].Score;
 
-  free ( A );
+  delete[] A;
 
   return Best;
 }
@@ -837,7 +837,7 @@ void outputPseudoMolecule
 
 
   //-- Read in the needed query contig sequences
-  A = (char *) Safe_malloc ( sizeof(char) * InitSize );
+  A = new char[InitSize];
   while ( Read_String (QryFile, A, InitSize, Line, false) )
     {
       for ( Cp = Contigs.begin( ); Cp < Contigs.end( ); Cp ++ )
@@ -848,15 +848,14 @@ void outputPseudoMolecule
       if ( Cp < Contigs.end( ) )
 	{
 	  assert ( (long int)strlen(A+1) == Cp->SeqLenQ );
-	  Cp->SeqQ = (char *) Safe_malloc
-	    ( sizeof(char) * (Cp->SeqLenQ + 2) );
+	  Cp->SeqQ = new char [Cp->SeqLenQ + 2];
 	  Cp->SeqQ[0] = '\0';
 	  strcpy ( Cp->SeqQ + 1, A + 1 );
 	  if ( Cp->DirQ == REVERSE_CHAR )
 	    Reverse_Complement (Cp->SeqQ, 1, Cp->SeqLenQ);
 	}
     }
-  free ( A );
+  delete[] A;
 
   //-- For all contigs, create pseudo
   for ( beginCp = Contigs.begin( ); beginCp < Contigs.end( ); beginCp ++ )
@@ -929,7 +928,7 @@ void outputPseudoMolecule
 		  fputc ('\n', Output);
 		}
 	    }
-	  free (Cp->SeqQ);
+	  delete[] Cp->SeqQ;
 
 	  //-- Print the gap
 	  for ( i = 1; i <= gap; i ++ )
@@ -1052,8 +1051,8 @@ void parseDelta
       aStats.SeqLenR = dr.getRecord( ).lenR;
       aContig.SeqLenQ = dr.getRecord( ).lenQ;
       
-      aStats.IdR = (char *) Safe_malloc (dr.getRecord( ).idR.length( ) + 1);
-      aContig.IdQ = (char *) Safe_malloc (dr.getRecord( ).idQ.length( ) + 1);
+      aStats.IdR = new char[dr.getRecord( ).idR.length( ) + 1];
+      aContig.IdQ = new char[dr.getRecord( ).idQ.length( ) + 1];
       strcpy (aStats.IdR, dr.getRecord( ).idR.c_str( ));
       strcpy (aContig.IdQ, dr.getRecord( ).idQ.c_str( ));
 


### PR DESCRIPTION
Only the last patch in this series is really needed.

When loading query sequences, it was not correct the break out of the loop on the first contig with the right name.  The contig could occur multiple times in the list, possibly with different +/- directions.  We need to copy the data for each instance.