### PR TITLE
Fix build on powerpc64(le)

### DIFF
--- a/include/mummer/postnuc.hh
+++ b/include/mummer/postnuc.hh
@@ -67,7 +67,7 @@ struct Alignment
                                 //      trust me, it is a very helpful value
   long int         Errors, SimErrors, NonAlphas; // errors, similarity errors, nonalphas
 
-  Alignment(const Match& m, const char dir)
+  Alignment(const Match& m, const signed char dir)
     : dirB(dir)
     , sA(m.sA)
     , sB(m.sB)


### PR DESCRIPTION
dir should be signed, same as a class variable dirB. Otherwise build fails on PPC:
```
src/tigr/postnuc.cc:174:37: error: non-constant-expression cannot be narrowed from type 'signed char' to 'char' in initializer list [-Wc++11-narrowing]
        Alignments.push_back({ *Mp, CurrCp->dirB } );
                                    ^~~~~~~~~~~~
src/tigr/postnuc.cc:174:37: note: insert an explicit cast to silence this issue
        Alignments.push_back({ *Mp, CurrCp->dirB } );
                                    ^~~~~~~~~~~~
                                    static_cast<char>( )
1 error generated.
```