### PR TITLE
Add Dockerfile; allow gnuplot to be specified in PATH

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+*.md
+.dockerignore
+.git
+docs
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM debian:10-slim AS builder
+
+RUN apt update && apt install -y --no-install-recommends \
+  autoconf \
+  automake \
+  g++ \
+  libtool \
+  make \
+  yaggo \
+  && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /usr/src
+
+COPY . .
+
+RUN autoreconf -fi \
+  && ./configure \
+  && make \
+  && make install
+
+# optionally run tests
+#RUN make check || cat ./test-suite.log && exit 1
+
+FROM debian:10-slim
+
+RUN apt update && apt install -y --no-install-recommends \
+  gnuplot \
+  libgomp1 \
+  perl \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /usr/local /usr/local
+RUN ldconfig

--- a/Makefile.am
+++ b/Makefile.am
@@ -154,13 +154,11 @@ CLEANFILES += $(libs_scripts) $(all_scripts)
 script_inst_subst  = sed -e 's,[@]PERL[@],$(PERL),g' \
                        -e 's,[@]BIN_DIR[@],$(bindir),g' \
                        -e 's,[@]LIB_DIR[@],$(script_libdir),g' \
-	               -e 's,[@]LIBEXEC_DIR[@],$(pkglibexecdir),g' \
-		       -e 's,[@]GNUPLOT_EXE[@],$(GNUPLOT),g'
+	               -e 's,[@]LIBEXEC_DIR[@],$(pkglibexecdir),g'
 script_local_subst = sed -e 's,[@]PERL[@],$(PERL),g' \
                        -e 's,[@]BIN_DIR[@],$(abs_builddir),g' \
                        -e 's,[@]LIB_DIR[@],$(abs_srcdir)/scripts,g' \
-	               -e 's,[@]LIBEXEC_DIR[@],$(abs_builddir),g' \
-                       -e 's,[@]GNUPLOT_EXE[@],$(GNUPLOT),g'
+	               -e 's,[@]LIBEXEC_DIR[@],$(abs_builddir),g'
 
 .libs/%: scripts/%.pl
 	@mkdir -p $(dir $@) && $(script_inst_subst) < $< > $@

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Master | Develop
 
 # MUMmer4.x README
 
-MUMmer is a versatile alignment tool for DNA and protein sequences. To install the software, download the [latest release](../../releases) and follow the [installation instructions](INSTALL.md).
+MUMmer is a versatile alignment tool for DNA and protein sequences. To install the software, download the [latest release](../../releases) and follow the [installation instructions](INSTALL.md). Alternatively, a Docker image can be built, and mummer executed in a Docker container, following the directions in the [Docker container](#docker-container) section.
 
 **NOTE**
 
@@ -798,6 +798,19 @@ format that can be accepted by TIGR's open source scaffolding software
 The programs `mapview`, `run-mummer1`, `run-mummer3` and `nucmer2xfig`
 are now obsolete. The original documentation is still available in
 [OBSOLETE.md](OBSOLETE.md).
+
+## Docker container
+To build a Docker container image containing mummer and all dependencies, [install Docker](https://docs.docker.com/get-docker/) for Windows, Mac, or Linux; clone the mummer git repo; and issue the following command in the top-level directory of the mummer git working tree:
+
+    docker build -t mummer .
+
+To execute individual mummer commands (e.g., nucmer) within a container:
+
+    docker run --rm -v $PWD:/mnt -w /mnt mummer nucmer -p <prefix> ref.fa  qry.fa
+
+To execute an interactive shell within a container (from which mummer commands can be executed):
+
+    docker run -it --rm -v $PWD:/mnt -w /mnt mummer
 
 ## CONTACT INFORMATION
 

--- a/configure.ac
+++ b/configure.ac
@@ -33,10 +33,6 @@ AS_IF([test "x$enable_openmp" != "xno"],
 AC_ARG_VAR([YAGGO], [Yaggo switch parser generator])
 AS_IF([test "x$YAGGO" = "x"], [AC_PATH_PROG([YAGGO], [yaggo], [false])])
 
-# Check for gnuplot
-AC_ARG_VAR([GNUPLOT], [Gnuplot plotting program])
-AS_IF([test "x$GNUPLOT" = "x"], [AC_PATH_PROGS([GNUPLOT], [gnuplot gnuplot5 gnuplot4], [false])])
-
 # Check that type __int128 is supported and if the
 AC_ARG_WITH([int128],
             [AS_HELP_STRING([--with-int128], [enable int128])],

--- a/scripts/mummerplot.pl
+++ b/scripts/mummerplot.pl
@@ -23,7 +23,7 @@ use IO::Socket;
 
 my $BIN_DIR     = "@BIN_DIR@";
 my $LIB_DIR     = "@LIB_DIR@";
-my $GNUPLOT_EXE = "@GNUPLOT_EXE@";
+my $GNUPLOT_EXE = "gnuplot";
 
 
 #================================================================= Globals ====#


### PR DESCRIPTION
This PR suggests a basic Dockerfile to facilitate easy, reproducible mummer installations with all dependencies. This Dockerfile suggests a [multi-stage build](https://docs.docker.com/develop/develop-images/multistage-build/) to make the final container image (which omits developer tools) smaller.

Note this image has received only light testing (though a `RUN make check` at the end of the "builder" stage should pass all regression tests, except tests/sam.sh, as previously reported in issue #147).

Also, this PR suggests implementing the mummerplot workaround noted in https://github.com/mummer4/mummer/issues/36#issuecomment-420684643, to assume the `gnuplot` executable is available in the user's PATH, rather than hard-coding an absolute pathname at mummer install time. This mod allows this multi-stage Dockerfile to omit the gnuplot installation (which has many dependencies) from the first "builder" stage, would facilitate using  mummerplot with the [bioconda mummer4 recipe](https://bioconda.github.io/recipes/mummer4/README.html) (which currently does not specify gnuplot as a dependency, but if it did, the absolute path of gnuplot at build time would not be the same as its absolute path in the end-user's conda environment),  would allow the use of mummerplot in from a typical HPC software environment that uses environment modules to set the user's PATH to installed software locations, and would allow gnuplot to be installed subsequent to mummer4 in a local installation.

