### PR TITLE
stdin for show-snps + autotools version in Dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ missing
 autom4te.cache
 compile
 test-driver
+*

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,3 @@ missing
 autom4te.cache
 compile
 test-driver
-*

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,7 +9,7 @@ essential tools for compilation (GNU make, ar, etc. Install
 requirements are needed to compile the SWIG script bindings. See the
 [SWIG installation guide](swig/INSTALL.md).
 
-If compiling from the github development tree, additionally you need autotools (autoconf, automake and libtools),
+If compiling from the github development tree, additionally you need autotools (autoconf, automake and libtools) version >= 1.14,
 [yaggo](https://github.com/gmarcais/yaggo/releases).
 You should compile from a [release source tarball](../../releases), unless you plan on modifying the code of MUMmer.
 

--- a/include/mummer/delta.hh
+++ b/include/mummer/delta.hh
@@ -214,6 +214,7 @@ public:
   //! \return void
   //!
   void open (const std::string & delta_path);
+  void openStdin ();
 
 
   //--------------------------------------------------- close ------------------
@@ -491,6 +492,7 @@ public:
   { clear(); }
 
   void build(const std::string & deltapath, bool getdeltas = true);
+  void buildStdin(bool getdeltas = true);
   void clean();
   void clear();
   long getNodeCount();

--- a/include/mummer/delta.hh
+++ b/include/mummer/delta.hh
@@ -513,7 +513,8 @@ public:
   void flagUNIQ(float minuniq);
 
   void loadSequences();
-  std::ostream & outputDelta(std::ostream & out);
+  std::ostream & outputDelta(std::ostream & out, bool OPT_PrintHeader);
+  std::ostream & outputIdy(std::ostream & out);
 };
 
 #endif // #ifndef __DELTA_HH

--- a/include/mummer/delta.hh
+++ b/include/mummer/delta.hh
@@ -509,7 +509,7 @@ public:
   void flagRLIS(float epsilon = -1,
                 float maxolap = 100.0,
                 bool flagbad = true);
-  void flagScore(long minlen, float minidy);
+  void flagScore(long minlen, float minidy, long minseqlen);
   void flagUNIQ(float minuniq);
 
   void loadSequences();

--- a/src/tigr/delta-filter.cc
+++ b/src/tigr/delta-filter.cc
@@ -33,6 +33,7 @@ bool           OPT_RLIS         = false;     // do reference based LIS
 bool           OPT_GLIS         = false;     // do global LIS
 bool           OPT_1to1         = false;     // do 1-to-1 alignment
 bool           OPT_MtoM         = false;     // do M-to-M alignment
+bool           OPT_PrintHeader  = true;      // print output header
 string         OPT_PrintIdentity = "identity.idy";           // path to print %identity
 long int       OPT_MinLength    = 0;         // minimum alignment length
 long int       OPT_MinSeqLength    = 0;         // minimum alignment length
@@ -117,7 +118,11 @@ int main(int argc, char ** argv)
     graph.flag1to1(OPT_Epsilon, OPT_MaxOverlap);
 
   //-- Output the filtered delta file
-  graph.outputDelta(cout);
+  graph.outputDelta(cout, OPT_PrintHeader);
+
+  std::ofstream outfile(OPT_PrintIdentity);
+  graph.outputIdy(outfile);
+  outfile.close();
 
   return EXIT_SUCCESS;
 }
@@ -132,7 +137,7 @@ void ParseArgs(int argc, char ** argv)
   optarg = NULL;
   
   while ( !errflg  &&
-         ((ch = getopt(argc, argv, "e:ghi:I:L:l:o:qru:m1")) != EOF) )
+         ((ch = getopt(argc, argv, "e:ghHi:I:L:l:o:qru:m1")) != EOF) )
     switch (ch)
       {
       case 'e':
@@ -146,6 +151,10 @@ void ParseArgs(int argc, char ** argv)
       case 'h':
         PrintHelp(argv[0]);
         exit(EXIT_SUCCESS);
+        break;
+
+      case 'H':
+        OPT_PrintHeader = false;
         break;
 
       case 'i':
@@ -238,6 +247,7 @@ void PrintHelp(const char * s)
     << "              (intersection of -r and -q alignments)\n"
     << "-g            1-to-1 global alignment not allowing rearrangements\n"
     << "-h            Display help information\n"
+    << "-H            Do not print the output header\n"
     << "-i float      Set the minimum alignment identity [0, 100], default "
     << OPT_MinIdentity << endl
     << "-I string     Print identity value, default "
@@ -296,14 +306,14 @@ int FilterDelta(std::istream& is, float min_len, float min_idy) {
   std::string line;
   // Print header unmodified
   std::getline(is, line);
-  std::cout << line << '\n';
+  if (OPT_PrintHeader) std::cout << line << '\n';
   std::getline(is, line);
   const bool promer = line == PROMER_STRING;
   if(!promer && line != NUCMER_STRING) {
     std::cerr << "Unsupported format '" << line << "'\n";
     return EXIT_FAILURE;
   }
-  std::cout << line << '\n';
+  if (OPT_PrintHeader) std::cout << line << '\n';
 
   int c = is.peek();
   if(c != '>') {

--- a/src/tigr/delta-filter.cc
+++ b/src/tigr/delta-filter.cc
@@ -36,7 +36,7 @@ bool           OPT_MtoM         = false;     // do M-to-M alignment
 bool           OPT_PrintHeader  = true;      // print output header
 string         OPT_PrintIdentity = "identity.idy";           // path to print %identity
 long int       OPT_MinLength    = 0;         // minimum alignment length
-long int       OPT_MinSeqLength    = 0;         // minimum alignment length
+long int       OPT_MinSeqLength    = 0;         // minimum sequence length
 float          OPT_MinIdentity  = 0.0;       // minimum %identity
 float          OPT_MinUnique    = 0.0;       // minimum %unique
 float          OPT_MaxOverlap   = 100.0;     // maximum olap as % of align len
@@ -90,8 +90,8 @@ int main(int argc, char ** argv)
   graph.build(OPT_AlignName, true);
 
   //-- Identity requirements
-  if ( OPT_MinIdentity > 0  ||  OPT_MinLength > 0 )
-    graph.flagScore(OPT_MinLength, OPT_MinIdentity);
+  if ( OPT_MinIdentity > 0  ||  OPT_MinLength > 0  || OPT_MinSeqLength > 0)
+    graph.flagScore(OPT_MinLength, OPT_MinIdentity, OPT_MinSeqLength);
 
   //-- Uniqueness requirements
   if ( OPT_MinUnique > 0 )

--- a/src/tigr/delta-filter.cc
+++ b/src/tigr/delta-filter.cc
@@ -33,6 +33,7 @@ bool           OPT_RLIS         = false;     // do reference based LIS
 bool           OPT_GLIS         = false;     // do global LIS
 bool           OPT_1to1         = false;     // do 1-to-1 alignment
 bool           OPT_MtoM         = false;     // do M-to-M alignment
+string         OPT_PrintIdentity = "identity.idy";           // path to print %identity
 long int       OPT_MinLength    = 0;         // minimum alignment length
 float          OPT_MinIdentity  = 0.0;       // minimum %identity
 float          OPT_MinUnique    = 0.0;       // minimum %unique
@@ -130,7 +131,7 @@ void ParseArgs(int argc, char ** argv)
   optarg = NULL;
   
   while ( !errflg  &&
-         ((ch = getopt(argc, argv, "e:ghi:l:o:qru:m1")) != EOF) )
+         ((ch = getopt(argc, argv, "e:ghi:I:l:o:qru:m1")) != EOF) )
     switch (ch)
       {
       case 'e':
@@ -150,13 +151,17 @@ void ParseArgs(int argc, char ** argv)
         OPT_MinIdentity = atof(optarg);
         break;
 
+      case 'I':
+        OPT_PrintIdentity = optarg;
+        break;
+
       case 'l':
         OPT_MinLength = atol(optarg);
         break;
 
       case 'o':
-	OPT_MaxOverlap = atof(optarg);
-	break;
+	      OPT_MaxOverlap = atof(optarg);
+	      break;
 
       case 'q':
         OPT_QLIS = true;
@@ -230,6 +235,7 @@ void PrintHelp(const char * s)
     << "-h            Display help information\n"
     << "-i float      Set the minimum alignment identity [0, 100], default "
     << OPT_MinIdentity << endl
+    << "-I string     Print "
     << "-l int        Set the minimum alignment length, default "
     << OPT_MinLength << endl
     << "-m            Many-to-many alignment allowing for rearrangements\n"
@@ -300,6 +306,7 @@ int FilterDelta(std::istream& is, float min_len, float min_idy) {
   DeltaRecord_t record;
   DeltaAlignment_t alignment;
 
+  std::ofstream outfile(OPT_PrintIdentity); // Open the output file
   while(c != EOF) {
     is >> record;
     bool first = true;
@@ -311,10 +318,12 @@ int FilterDelta(std::istream& is, float min_len, float min_idy) {
         continue;
       if(first) {
         std::cout << record << '\n';
+        outfile << record << " " << alignment.idy << '\n';
         first = false;
       }
       std::cout << alignment;
     }
   }
+  outfile.close();
   return EXIT_SUCCESS;
 }

--- a/src/tigr/delta.cc
+++ b/src/tigr/delta.cc
@@ -1387,6 +1387,7 @@ void DeltaGraph_t::loadSequences ()
         if ( len != mi->second.len )
           {
             cerr << "ERROR: Query input does not match delta file\n";
+            cerr << "Error occured in " << id << "\n";
             exit (EXIT_FAILURE);
           }
       }
@@ -1417,7 +1418,7 @@ void DeltaGraph_t::loadSequences ()
 //! \param out The output stream to write to
 //! \return The output stream
 //!
-ostream & DeltaGraph_t::outputDelta (ostream & out)
+ostream & DeltaGraph_t::outputDelta (ostream & out, bool OPT_PrintHeader)
 {
   bool header;
   long s1, e1, s2, e2;
@@ -1427,9 +1428,11 @@ ostream & DeltaGraph_t::outputDelta (ostream & out)
   vector<DeltaEdgelet_t *>::const_iterator eli;
  
   //-- Print the file header
-  cout
-    << refpath << ' ' << qrypath << '\n'
-    << (datatype == PROMER_DATA ? PROMER_STRING : NUCMER_STRING) << '\n';
+  if (OPT_PrintHeader) {
+    cout
+      << refpath << ' ' << qrypath << '\n'
+      << (datatype == PROMER_DATA ? PROMER_STRING : NUCMER_STRING) << '\n';
+  }
  
   for ( mi = qrynodes.begin(); mi != qrynodes.end(); ++ mi )
     {
@@ -1471,6 +1474,37 @@ ostream & DeltaGraph_t::outputDelta (ostream & out)
                 << (*eli)->simc << ' '
                 << (*eli)->stpc << '\n'
                 << (*eli)->delta;
+            }
+        }
+    }
+  return out;
+}
+
+ostream & DeltaGraph_t::outputIdy (ostream & out)
+{ 
+  map<string, DeltaNode_t>::const_iterator mi;
+  vector<DeltaEdge_t *>::const_iterator ei;
+  vector<DeltaEdgelet_t *>::const_iterator eli;
+
+  for ( mi = qrynodes.begin(); mi != qrynodes.end(); ++ mi )
+    {
+      for ( ei  = (mi->second).edges.begin();
+            ei != (mi->second).edges.end(); ++ ei )
+        {
+ 
+          for ( eli  = (*ei)->edgelets.begin();
+                eli != (*ei)->edgelets.end(); ++ eli )
+            {
+              if ( ! (*eli)->isGOOD )
+                continue;
+ 
+              out
+                << '>'
+                << *((*ei)->refnode->id) << ' '
+                << *((*ei)->qrynode->id) << ' '
+                << (*ei)->refnode->len << ' '
+                << (*ei)->qrynode->len << ' '
+                << (*eli)->idy << '\n';
             }
         }
     }

--- a/src/tigr/delta.cc
+++ b/src/tigr/delta.cc
@@ -1491,6 +1491,7 @@ ostream & DeltaGraph_t::outputIdy (ostream & out)
   vector<DeltaEdgelet_t *>::const_iterator eli;
 
   long idycTotal;
+  long refMatchedTotal;
   double idy = 0;
   bool pass;
 
@@ -1500,6 +1501,7 @@ ostream & DeltaGraph_t::outputIdy (ostream & out)
             ei != (mi->second).edges.end(); ++ ei )
         {
           idycTotal = 0;
+          refMatchedTotal = 0;
           pass = true;
           
           for ( eli  = (*ei)->edgelets.begin();
@@ -1508,15 +1510,16 @@ ostream & DeltaGraph_t::outputIdy (ostream & out)
               if ( (*eli)->isGOOD )
                 pass = false;
               idycTotal += (*eli)->idyc;
+              refMatchedTotal += (*eli)->hiR - (*eli)->loR + 1;
             }
           if (pass != true)
           {
 
-            if ((*ei)->refnode->len > (*ei)->qrynode->len)
+            if ((*ei)->refnode->len < (*ei)->qrynode->len)
             {
-              idy = (double)(((*ei)->qrynode->len - idycTotal)) / (double)((*ei)->qrynode->len);
+              idy = (double)(((*ei)->qrynode->len - idycTotal - ((*ei)->refnode->len - refMatchedTotal))) / (double)((*ei)->qrynode->len);
             }else{
-              idy = (double)(((*ei)->refnode->len - idycTotal)) / (double)((*ei)->refnode->len);
+              idy = (double)(((*ei)->refnode->len - idycTotal - ((*ei)->refnode->len - refMatchedTotal))) / (double)((*ei)->refnode->len);
             }
             out
               << '>'


### PR DESCRIPTION
Sometimes, it is convenient to pass data as standard input when using the "show-snps" command. This PR suggests adding the "-s" tag for show-snps, which allows standard input instead of a deltafile.

Furthermore, during the installation of MUMmer, there have been cases where it fails due to version conflicts with autotools. I have added the version information to the Dependencies as mentioned in Issue #12.