### PR TITLE
Feature/bsd compilation

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -2,49 +2,64 @@ name: C/C++ CI
 
 on:
   push:
-    branches: [ master, develop, 'release/**' ]
+    branches: [master, develop, "release/**", "feature/**"]
   pull_request:
-    branches: [ master, develop  ]
+    branches: [master, develop]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: dependencies
-      run: |
-        sudo apt-get update
-        sudo DEBIAN_FRONTEND=noninteractive apt-get install -y yaggo gettext swig python3-dev ruby-dev libperl-dev
-    - name: autotools
-      run: autoreconf -fi
-    - name: configure
-      run: ./configure --enable-all-binding --enable-swig
+      - uses: actions/checkout@v3
+      - name: dependencies
+        run: |
+          sudo apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y yaggo gettext swig python3-dev ruby-dev libperl-dev
+      - name: autotools
+        run: autoreconf -fi
+      - name: configure
+        run: ./configure --enable-all-binding --enable-swig
 
-    - name: make
-      run: make -j$(nproc)
+      - name: make
+        run: make -j$(nproc)
 
-    - name: make check
-      run: make -j$(nproc) check
-    - name: Check logs
-      if: failure()
-      uses: actions/upload-artifact@v4
-      with:
-        name: checklog
-        path: "**/*tests/*.log"
+      - name: make check
+        run: make -j$(nproc) check
+      - name: Check logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: checklog
+          path: "**/*tests/*.log"
 
-    - name: make distcheck
-      run: make -j$(nproc) distcheck
-    - name: Distcheck logs
-      if: failure()
-      uses: actions/upload-artifact@v4
-      with:
-        name: distchecklog
-        path: |
-          **/*tests/*.log
-          **/*tests/**/tee.*
+      - name: make distcheck
+        run: make -j$(nproc) distcheck
+      - name: Distcheck logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: distchecklog
+          path: |
+            **/*tests/*.log
+            **/*tests/**/tee.*
 
-    - name: Distribution tar ball
-      uses: actions/upload-artifact@v4
-      with:
-        name: disttarball
-        path: "mummer-*.tar.gz"
+      - name: Distribution tar ball
+        uses: actions/upload-artifact@v4
+        with:
+          name: disttarball
+          path: "mummer-*.tar.gz"
+
+  testbsd:
+    runs-on: ubuntu-latest
+    name: Compile on FreeBSD
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test in FreeBSD
+        id: test
+        uses: vmactions/freebsd-vm@v1
+        with:
+          usesh: true
+          prepare: |
+            pkg install -y gmake yaggo autoconf automake libtool
+          run: |
+            autoreconf -fi && ./configure MAKE=gmake && gmake check

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -60,6 +60,6 @@ jobs:
         with:
           usesh: true
           prepare: |
-            pkg install -y gmake yaggo autoconf automake libtool
+            pkg install -y gmake yaggo autoconf automake libtool bash
           run: |
             autoreconf -fi && ./configure MAKE=gmake && gmake check

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -63,3 +63,26 @@ jobs:
             pkg install -y gmake yaggo autoconf automake libtool bash
           run: |
             autoreconf -fi && ./configure MAKE=gmake && gmake check
+
+  testmacos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: dependencies
+        run: |
+          brew install autoconf automake libtool md5sha1sum
+          gem install yaggo
+      - name: autotools
+        run: autoreconf -fi
+      - name: configure
+        run: ./configure
+      - name: make
+        run: make -j$(sysctl -n hw.ncpu)
+      - name: make check
+        run: make -j$(sysctl -n hw.ncpu) check
+      - name: Check logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: checklog
+          path: "**/*tests/*.log"

--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -60,9 +60,11 @@ jobs:
         with:
           usesh: true
           prepare: |
-            pkg install -y gmake yaggo autoconf automake libtool bash
+            pkg install -y gmake yaggo autoconf automake libtool bash gcc14
           run: |
-            autoreconf -fi && ./configure MAKE=gmake && gmake check
+            autoreconf -fi && \
+            ./configure MAKE=gmake CC=gcc14 CXX=g++14 LDFLAGS=-Wl,-rpath=/usr/local/lib/gcc14 && \
+            gmake -j $(sysctl -n hw.ncpu) check
 
   testmacos:
     runs-on: macos-latest
@@ -75,7 +77,7 @@ jobs:
       - name: autotools
         run: autoreconf -fi
       - name: configure
-        run: ./configure
+        run: ./configure CC=gcc-14 CXX=g++-14
       - name: make
         run: make -j$(sysctl -n hw.ncpu)
       - name: make check

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,16 @@
 -- Version history --
 
+4.0.0  48bit suffix array. Go past previous sequence length limitations
+       nucmer is all C++ (not Perl script) and multi-threaded
+       nucmer can save the SA index for later reuse
+       Added SAM output format to nucmer
+       Moved to autoconf compilation system
+       Bindings to scripting language: Python, Perl, Ruby
+       Improved mummerplot
+       Better unittesting and conformance testing
+       Provide a library with pkg-conig configuration
+       Moved to artistic license 2.0
+       Moved to C++17 standard.
 3.23 - Added -D and --banded option to nucmer. These options can be used to
        specify the largest indel that will be included in an alignment
        segment without breaking it in two pieces.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,46 +1,89 @@
-# MUMmer4 INSTALLATION README
+# MUMmer4 Compilation README
 
 ## Dependencies
 
-If compiling from a [release source tarball](../../releases) you need a
-recent version of the GCC compiler (g++ version >= 4.7) and other
-essential tools for compilation (GNU make, ar, etc. Install
-`build-essentials` on Debian or Ubuntu derivatives).  Additional
-requirements are needed to compile the SWIG script bindings. See the
-[SWIG installation guide](swig/INSTALL.md).
+If compiling from a [release source tarball](../../releases) (recommended), you need a recent version of the GCC compiler (see below, only GCC is supported) and other essential tools for compilation (GNU make, ar, etc).
+Additional requirements are needed to compile the SWIG script bindings.
+See the [SWIG installation guide](swig/INSTALL.md).
 
-If compiling from the github development tree, additionally you need autotools (autoconf, automake and libtools),
-[yaggo](https://github.com/gmarcais/yaggo/releases).
-You should compile from a [release source tarball](../../releases), unless you plan on modifying the code of MUMmer.
+If compiling from the github development tree, additionally you need autotools (autoconf, automake and libtools), [yaggo](https://github.com/gmarcais/yaggo/releases).
 
-On Ubuntu:
+### On Ubuntu
 
+From the tarball:
 ```Shell
-sudo apt install git build-essential yaggo autoconf automake libtool gettext
+sudo apt install build-essential
 # For the bindings to scripting, additionally install
 sudo apt install swig python3-dev ruby-dev libperl-dev
 ```
 
-## Compilation & Installation
+From the git tree:
+```Shell
+sudo apt instaoo build-essential git yaggo autoconf automake libtool gettext
+# For the bindings to scripting, additionally install
+sudo apt install swig python3-dev ruby-dev libperl-dev
+```
 
-To compile and install from a [release source tarball](../../releases):
+### On Mac OS
+
+MUMmer must be compiled with GCC, not Clang (and not the Apple provided `gcc` which is really `clang`).
+Install with Brew:
 
 ```Shell
+brew install autoconf automake libtool md5sha1sum
+gem install yaggo
+```
+
+### On FreeBSD
+
+MUMmer must be compiled with GCC, not Clang.
+Install with Brew:
+
+```Shell
+brew install autoconf automake libtool md5sha1sum bash
+gem install yaggo
+```
+
+
+## Compilation & Installation
+
+If compiling from the release tarball (recommended), then the first command `autoreconf -fi` is not necessary.
+
+### On Ubuntu
+
+```Shell
+autoreconf -fi # Optional, on if compiling from git tree
 ./configure --prefix=/path/to/installation
 make
+make check # Optional
 make install
 ```
 
-If `--prefix` is omitted, the software is installed in
-`/usr/local`. One may need `sudo make install` if installing in a
-system location.
+If `--prefix` is omitted, the software is installed in `/usr/local`.
+One may need `sudo make install` if installing in a system location.
 
-To compile from the github tree, `autoreconf` must additionally be run:
+### On MacOS
+
+Compile with `gcc-14`.
+
 ```Shell
-autoreconf -fi
-./configure --prefix=/path/to/installation
+autoreconf -fi # Optional, on if compiling from git tree
+./configure --prefix=/path/to/installation CC=gcc-14 CXX=g++-14
 make
+make check # Optional
 make install
+```
+
+### On FreeBSD
+
+Compile with `gcc14`.
+
+```Shell
+autoreconf -fi # Optional, on if compiling from git tree
+./configure --prefix=/path/to/installation MAKE=gmake CC=gcc14 CXX=g++14 LDFLAGS=-Wl,-rpath=/usr/local/lib/gcc14
+gmake
+gmake check # Optional
+gmake install
 ```
 
 ## SOFTWARE REQUIREMENTS

--- a/include/thread_pipe.hpp
+++ b/include/thread_pipe.hpp
@@ -48,6 +48,7 @@ class ostream_buffered : public consumer<ostream_buffered, stringstream_wrapper>
   std::ostream& os_;
 public:
   ostream_buffered(std::ostream& os) : os_(os) { }
+  ~ostream_buffered() { close(); }
   bool operator()(stringstream_wrapper& e) {
     bool res = false;
     auto rdbuf = e.p_->rdbuf();

--- a/src/tigr/show-aligns.cc
+++ b/src/tigr/show-aligns.cc
@@ -696,7 +696,8 @@ void append(ColoredBuffer& Buff1, ColoredBuffer& Buff2, std::string &Buff3,
 
 void add_prefix(ColoredBuffer& Buff, long int pos, long int seqlen, int frame) {
   char b[LINE_BUFFER_LEN + 1];
-  sprintf(b, PREFIX_FORMAT, toFwd(pos, seqlen, frame));
+  snprintf(b, sizeof(b), PREFIX_FORMAT, toFwd(pos, seqlen, frame));
+  b[sizeof(b)-1] = '\0';
   Buff.clear();
   Buff += b;
 }

--- a/tests/gcc10_uniform_dist.hpp
+++ b/tests/gcc10_uniform_dist.hpp
@@ -36,6 +36,10 @@
 #ifndef _GCC10_UNIFORM_DIST_H
 #define _GCC10_UNIFORM_DIST_H
 
+#ifndef __glibcxx_assert
+#define __glibcxx_assert(x)
+#endif
+
 #include <type_traits>
 #include <limits>
 

--- a/tests/genome.sh
+++ b/tests/genome.sh
@@ -1,2 +1,2 @@
-time  sed -e 's/^>\([^[:space:]]\+\).*/>\1/' $D/seed_reads_2.fa | tee genome | nucmer -G --delta /dev/stdout $D/seed_genome.fa /dev/stdin | \
+time  sed -E 's/^>([^[:space:]]+).*/>\1/' "${D}/seed_reads_2.fa" | tee genome | nucmer -G --delta /dev/stdout "${D}/seed_genome.fa" /dev/stdin | \
     tee genome.delta | tail -n +3 | test_md5 8328b1577d8656eaa53aa61a113d89b0

--- a/tests/mummer.sh
+++ b/tests/mummer.sh
@@ -1,2 +1,2 @@
-mummer -mum $D/seed_reads_1.fa $D/seed_reads_0.fa | ufasta hsort -H | ufasta dsort | test_md5 4e8182c9f745abf59158f69a05b942f3
-mummer -maxmatch $D/seed_reads_1.fa $D/seed_reads_0.fa | ufasta hsort -H | ufasta dsort | test_md5 a459f93742d1c36819e53e7a4c128bf7
+mummer -mum "${D}/seed_reads_1.fa" "${D}/seed_reads_0.fa" | ufasta hsort -H | ufasta dsort | test_md5 4e8182c9f745abf59158f69a05b942f3
+mummer -maxmatch "${D}/seed_reads_1.fa" "${D}/seed_reads_0.fa" | ufasta hsort -H | ufasta dsort | test_md5 a459f93742d1c36819e53e7a4c128bf7

--- a/tests/sam.sh
+++ b/tests/sam.sh
@@ -16,7 +16,7 @@ for i in 1 2; do
     [ "$(grep '^@PG' $f | head -c $pglen)" = "$pgline" ]
 
     # Test sequence headers
-    diff -q <(grep '^@SQ' $f) <(ufasta sizes -H $D/seed_reads_1.fa | sed 's/\([0-9]\+\) \([0-9]\+\)/@SQ\tSN:\1\tLN:\2/')
+    diff -q <(grep '^@SQ' $f) <(ufasta sizes -H $D/seed_reads_1.fa | sed -E 's/([0-9]+) ([0-9]+)/@SQ\tSN:\1\tLN:\2/')
 
     # Test that samtools can parse our output
     if [ -n "$SAMTOOLS" ]; then

--- a/tests/test_md5
+++ b/tests/test_md5
@@ -1,4 +1,9 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
-md5sum -c <(echo "$1  -") 2>&1 || \
-    test $(md5) == "$1" 2>&1
+# The semantic of md5sum differs in some subtle way. Darwin doesn't support
+# /dev/stdin, FreeBSD doesn't support "-". Linux supports both.
+
+case "$(uname)" in
+  (Darwin) exec md5sum -c <(echo "$1  -") 2>&1 ;;
+  (*) exec md5sum -c <(echo "$1  /dev/stdin") 2>&1 ;;
+esac

--- a/tests/testsh.in
+++ b/tests/testsh.in
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 set -e
 set -x
@@ -25,8 +25,6 @@ N=$(basename $1 .sh)
 WORKDIR=tests/$N
 mkdir -p $WORKDIR
 
-# Read script in fd 3 so that it is availabe after changing directory
-# (path to SCRIPT may not be absolute).
-exec 3<$SCRIPT
+SCRIPT=$(realpath $SCRIPT)
 cd $WORKDIR
-source /dev/fd/3
+source "$SCRIPT"

--- a/tests/testsh.in
+++ b/tests/testsh.in
@@ -18,7 +18,8 @@ SCRIPT=$1
 
 # Path to data
 D=$BUILD/tests/data
-PATH=$BUILD:$BUILD/tests:$SRC/tests:$PATH
+PATH=${BUILD}:${BUILD}/tests:${SRC}/tests:$PATH
+
 # Name
 N=$(basename $1 .sh)
 # Working directory

--- a/unittests/Makefile.am
+++ b/unittests/Makefile.am
@@ -20,8 +20,11 @@ EXTRA_DIST += $(GTEST_SRC)
 # Unittest programs #
 #####################
 unittests_programs = %D%/test_all
+unittests_script = %D%/unittests
 check_PROGRAMS += $(unittests_programs)
-TESTS += $(unittests_programs)
+TESTS += $(unittests_script)
+EXTRA_DIST += $(unittests_script)
+CLEANDIRS += %D%/tmp
 
 %C%_test_all_SOURCES = %D%/test_nucmer.cc %D%/test_cooperative_pool2.cc	    \
  %D%/test_whole_sequence_parser.cc %D%/test_sparse_sa.cc %D%/test_qsort.cc	\

--- a/unittests/Makefile.am
+++ b/unittests/Makefile.am
@@ -25,7 +25,7 @@ TESTS += $(unittests_programs)
 
 %C%_test_all_SOURCES = %D%/test_nucmer.cc %D%/test_cooperative_pool2.cc	    \
  %D%/test_whole_sequence_parser.cc %D%/test_sparse_sa.cc %D%/test_qsort.cc	\
- %D%/test_multi_thread_skip_list_set.cc
+ %D%/test_multi_thread_skip_list_set.cc %D%/test_thread_pipe.cc
 %C%_test_all_LDADD = $(LDADD) %D%/libgtest_main.la
 %C%_test_all_CXXFLAGS = $(AM_CXXFLAGS) -I$(srcdir)/unittests
 noinst_HEADERS += %D%/misc.hpp

--- a/unittests/test_thread_pipe.cc
+++ b/unittests/test_thread_pipe.cc
@@ -29,7 +29,7 @@ namespace {
     }
 
     TEST(ThreadPipe, MultipleProducers) {
-        static const char* file = "unittests/multipleproducers";
+        static const char* file = "multipleproducers";
         static const int nb_threads = 4;
 
         { // Write content to file

--- a/unittests/test_thread_pipe.cc
+++ b/unittests/test_thread_pipe.cc
@@ -1,0 +1,89 @@
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+#include <thread>
+#include <gtest/gtest.h>
+
+#include <thread_pipe.hpp>
+
+namespace {
+    // Sizes written and block size
+    static const size_t times = 100000;
+    static const size_t size = 67;
+    static const ssize_t block = 1024;
+
+    // Thread function: Output
+    void producer(thread_pipe::ostream_buffered* output, int thread_id) {
+        auto it = output->begin();
+
+        for(size_t i = 0; i < times; ++i) {
+            *it << thread_id;
+            for(size_t j = 0; j < size; ++j)
+              *it << ' ' << i;
+            *it << '\t';
+            if(it->tellp() > block)
+              ++it;
+        }
+        it.done();
+    }
+
+    TEST(ThreadPipe, MultipleProducers) {
+        static const char* file = "unittests/multipleproducers";
+        static const int nb_threads = 4;
+
+        { // Write content to file
+            std::ofstream os(file);
+            thread_pipe::ostream_buffered output(os);
+
+            std::vector<std::thread> threads;
+            for(int i = 0; i < nb_threads; ++i)
+                threads.push_back(std::thread(producer, &output, i));
+
+            for(auto& th : threads)
+                th.join();
+
+            EXPECT_TRUE(os.good());
+        }
+
+        { // Read and check content in file. It is tab separated
+            std::ifstream is(file);
+            std::vector<std::string> content;
+            std::string block;
+
+            while(std::getline(is, block, '\t')) {
+                content.push_back(block);
+            }
+
+            EXPECT_TRUE(is.eof());
+            EXPECT_EQ(times * (size_t)nb_threads, content.size());
+
+            // Expect every thread to have written lines in order, each line
+            // containing "times" order value.
+            std::vector<size_t> indices(nb_threads, 0);
+            std::istringstream iss;
+            int thid;
+            size_t count;
+            for(const auto& l : content) {
+                iss.str(l);
+                iss.clear();
+                iss >> thid;
+                EXPECT_TRUE(iss.good());
+                EXPECT_GE(thid, 0);
+                EXPECT_LT(thid, nb_threads);
+                for(size_t i = 0; i < size; ++i) {
+                    EXPECT_TRUE(iss.good()) << "thid " << this << " i " << i;
+                    iss >> count;
+                    EXPECT_EQ(indices[thid], count) << "thid " << thid;
+                }
+                iss >> count;
+                EXPECT_TRUE(iss.eof());
+                ++indices[thid];
+            }
+
+            for(const auto v : indices)
+                EXPECT_EQ(times, v);
+        }
+    }
+
+} // namespace

--- a/unittests/test_whole_sequence_parser.cc
+++ b/unittests/test_whole_sequence_parser.cc
@@ -28,7 +28,6 @@ TEST(SequenceParser, Fasta) {
   static const char* seq1 = "ATTACCTTGTACCTTCAGAGC";
   static const char* seq2 = "TTCGATCCCTTGATAATTAGTCACGTTAGCT";
   const char* file_name = "Fasta.fa";
-  file_unlink fu(file_name);
 
   {
     std::ofstream sequence(file_name);
@@ -73,7 +72,6 @@ TEST(SequenceParser, Fastq) {
   static const char* seq1 = "ATTACCTTGTACCTTCAGAGC";
   static const char* seq2 = "TTCGATCCCTTGATAATTAGTCACGTTAGCT";
   const char* file_name = "Fasta.fq";
-  file_unlink fu(file_name);
 
   {
     std::ofstream sequence(file_name);
@@ -126,7 +124,6 @@ TEST(SequenceParser, Fastq) {
 
 TEST(SequenceParser, FastaMany) {
   const char* file_name = "FastaMany.fa";
-  file_unlink fu(file_name);
   static const int nb_sequences = 1000;
 
   std::uniform_int_distribution<int> rand_byte(0, 255);

--- a/unittests/unittests
+++ b/unittests/unittests
@@ -1,0 +1,9 @@
+#! /usr/bin/env bash
+
+set -e
+
+pwd
+p=$(realpath unittests/test_all)
+mkdir -p unittests/tmp
+cd unittests/tmp
+exec $p


### PR DESCRIPTION
Fix compilation and testing errors on FreeBSD and MacOS.

Fixes #221 .

On FreeBSD and MacOS, MUMmer must be compiled with GCC. Clang on these platform (but not on Linux for some reason) generates an erroneous binary: it will fail the unit tests and compiance tests. See the [Github action workflow](.github/workflows/c-cpp.yml) or the [compilation documentation](INSTALL.md) for example on how to compile.